### PR TITLE
Fixes overly tolerant char-set? predicate

### DIFF
--- a/br-parser-tools-lib/br-parser-tools/private-lex/stx.rkt
+++ b/br-parser-tools-lib/br-parser-tools/private-lex/stx.rkt
@@ -147,6 +147,7 @@
   (check-equal? (char-set? '(repetition 1 2 #\1)) #f)
   (check-equal? (char-set? '(repetition 1 1 "12")) #f)
   (check-equal? (char-set? '(repetition 1 1 "1")) #t)
+  (check-equal? (char-set? '(repetition 6 6 "1")) #f)
   (check-equal? (char-set? '(union "1" "2" "3")) #t)
   (check-equal? (char-set? '(union "1" "" "3")) #f)
   (check-equal? (char-set? '(intersection "1" "2" (union "3" "4"))) #t)
@@ -182,4 +183,8 @@
   (check-equal? (parse #'(char-range #\1 "1") null) '(char-range #\1 #\1))
   (check-equal? (parse #'(char-range "1" "3") null) '(char-range #\1 #\3))
   (check-equal? (parse #'(char-complement (union "1" "2")) null)
-                '(char-complement (union "1" "2"))))
+                '(char-complement (union "1" "2")))
+  (check-equal? (parse #'(char-complement (repetition 1 1 "1")) null)
+                '(char-complement (repetition 1 1 "1")))
+  (check-exn #rx"not a character set"
+             (λ () (parse #'(char-complement (repetition 6 6 "1")) null))))

--- a/br-parser-tools-lib/br-parser-tools/private-lex/stx.rkt
+++ b/br-parser-tools-lib/br-parser-tools/private-lex/stx.rkt
@@ -134,7 +134,7 @@
     [(list? s-re) (case (car s-re)
                     [(union intersection) (andmap char-set? (cdr s-re))]
                     [(char-range char-complement) #t]
-                    [(repetition) (and (= (cadr s-re) (caddr s-re)) (char-set? (cadddr s-re)))]
+                    [(repetition) (and (= 1 (cadr s-re) (caddr s-re)) (char-set? (cadddr s-re)))]
                     [(concatenation) (and (= 2 (length s-re)) (char-set? (cadr s-re)))]
                     (else #f))]
     [else #f]))


### PR DESCRIPTION
I noticed this bug in Racket's parser-tools/lex, and after submitting [a PR](https://github.com/racket/parser-tools/pull/10) for that, I figured brag might suffer from it as well. Indeed, it does. This PR fixes the bug and includes a couple test cases to demonstrate the change.